### PR TITLE
fix: pin Elasticsearch version to 8.16

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,3 +1,3 @@
 elasticsearch==8.16.0
-tqdm
-argparse
+tqdm==4.67.1
+argparse==1.4.0

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,3 +1,3 @@
-elasticsearch
+elasticsearch==8.16.0
 tqdm
 argparse


### PR DESCRIPTION
This PR pins `elasticsearch` version to 8.16.0 to align with the workshop version of Elasticsearch and prevent it from updating to the next major version of the package until ready.